### PR TITLE
Enabled usage in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:2.7.16-alpine3.10
+
+ENV WORKDIR /src
+RUN mkdir -p ${WORKDIR}
+WORKDIR ${WORKDIR}
+
+COPY ./requirements.txt ${WORKDIR}/requirements.txt
+RUN pip install -r requirements.txt
+
+COPY ./ ${WORKDIR}/
+
+ENTRYPOINT ["python", "XssPy.py"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ You will also need the mechanize distribution, you can install it with pip:
 # Usage: 
 `python XssPy.py website.com` (Do not write www.website.com OR http://www.website.com)
 
+# Docker
+Advantage of Docker is that is will run on every machine. You don't need to install Pip packages or use a Venv.
+Package versions are pinned. This ensures that XssPy will also run in the future. Regardless which Python-Version you've running on you machine.
+## Docker build
+```
+docker build -ti xsspy .
+```
+## Docker usage
+After you build
+```
+docker run -ti xsspy website.com
+```
+
 # Payloads
 If you have found a XSS vulnerability, you can try the following payloads.
 http://pastebin.com/J1hCfL9J

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+html5lib==1.0.1
+mechanize==0.4.2
+six==1.12.0
+webencodings==0.5.1


### PR DESCRIPTION
Hi Faizan,

because Python 2.7 is running [EOL](https://pythonclock.org/), I thought it may be useful to enable Docker in your repository